### PR TITLE
Use CookieFile instead of UserPass for bitcoincore_rpc auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ const POOL_USERS: usize = 10;
 ```bash
 ./bitcoind -signet -addnode=inquisition.bitcoin-signet.net
 ```
+
 ```bash
-export BITCOIN_RPC_USER="rpc_username"
-export BITCOIN_RPC_PASS="rpc_password"
+export BITCOIN_RPC_COOKIE_PATH="/home/user/.bitcoin/signet/.cookie"
 export SIGNET_WALLET="signet wallet name"
 cargo run --no-default-features --features "signet"
 ```
@@ -101,8 +101,7 @@ in regtest we use P2A and v3 transactions to spend. I had a hard time trying to 
 ./bitcoind -regtest -minrelaytxfee=0 -fallbackfee=0.0001
 ```
 ```bash
-export BITCOIN_RPC_USER="rpc_username"
-export BITCOIN_RPC_PASS="rpc_password"
+export BITCOIN_RPC_COOKIE_PATH="/home/user/.bitcoin/regtest/.cookie"
 cargo run --features "regtest"
 ```
 ### Resources

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use bitcoin::{Amount, Network};
 
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 use tracing::info;
+use std::path::PathBuf;
 
 // https://bitcoinops.org/en/bitcoin-core-28-wallet-integration-guide/
 // mainnet: bc1pfeessrawgf
@@ -66,19 +67,23 @@ impl NetworkConfig {
     }
 
     pub fn bitcoin_rpc(&self) -> Client {
-        let bitcoin_rpc_user =
-            env::var("BITCOIN_RPC_USER").expect("BITCOIN_RPC_USER env var not set");
-        let bitcoin_rpc_pass =
-            env::var("BITCOIN_RPC_PASS").expect("BITCOIN_RPC_PASS env var not set");
+        let bitcoin_rpc_cookie_path =
+            env::var("BITCOIN_RPC_COOKIE_PATH").expect("BITCOIN_RPC_COOKIE_PATH env var not set");
+        //let bitcoin_rpc_user =
+            //env::var("BITCOIN_RPC_USER").expect("BITCOIN_RPC_USER env var not set");
+        //let bitcoin_rpc_pass =
+            //env::var("BITCOIN_RPC_PASS").expect("BITCOIN_RPC_PASS env var not set");
 
         let bitcoin_rpc_url =
             format!("http://localhost:{}/wallet/{}", self.port, self.wallet_name,);
 
         info!("wallet name in use: {} \n", self.wallet_name);
 
+        let cookie_path = PathBuf::from(bitcoin_rpc_cookie_path);
+
         let bitcoin_rpc = Client::new(
             &bitcoin_rpc_url,
-            Auth::UserPass(bitcoin_rpc_user, bitcoin_rpc_pass),
+            Auth::CookieFile(cookie_path),
         )
         .unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,7 @@
-use std::env;
-
 use bitcoin::{Amount, Network};
-
 use bitcoincore_rpc::{Auth, Client, RpcApi};
-use tracing::info;
 use std::path::PathBuf;
+use tracing::info;
 
 // https://bitcoinops.org/en/bitcoin-core-28-wallet-integration-guide/
 // mainnet: bc1pfeessrawgf
@@ -66,26 +63,75 @@ impl NetworkConfig {
         //wen mainnet
     }
 
+    pub fn get_env_var(var_name: &str, default_value: &str) -> String {
+        std::env::var(var_name).unwrap_or_else(|_| default_value.to_string())
+    }
+
     pub fn bitcoin_rpc(&self) -> Client {
-        let bitcoin_rpc_cookie_path =
-            env::var("BITCOIN_RPC_COOKIE_PATH").expect("BITCOIN_RPC_COOKIE_PATH env var not set");
-        //let bitcoin_rpc_user =
-            //env::var("BITCOIN_RPC_USER").expect("BITCOIN_RPC_USER env var not set");
-        //let bitcoin_rpc_pass =
-            //env::var("BITCOIN_RPC_PASS").expect("BITCOIN_RPC_PASS env var not set");
+        let bitcoin_rpc_user = Self::get_env_var("BITCOIN_RPC_USER", "NA");
+        let bitcoin_rpc_pass = Self::get_env_var("BITCOIN_RPC_PASS", "NA");
+        let bitcoin_rpc_cookie_path = Self::get_env_var("BITCOIN_RPC_COOKIE_PATH", "NA");
 
         let bitcoin_rpc_url =
             format!("http://localhost:{}/wallet/{}", self.port, self.wallet_name,);
 
         info!("wallet name in use: {} \n", self.wallet_name);
 
-        let cookie_path = PathBuf::from(bitcoin_rpc_cookie_path);
+        let bitcoin_rpc_user_clone = bitcoin_rpc_user.clone();
+        let bitcoin_rpc_pass_clone = bitcoin_rpc_pass.clone();
 
-        let bitcoin_rpc = Client::new(
-            &bitcoin_rpc_url,
-            Auth::CookieFile(cookie_path),
-        )
-        .unwrap();
+        let auth;
+        let bitcoin_rpc;
+        let test_auth;
+
+        //Check if user/pass or cookie is found in enviroment variables. 
+        //If both are found, UserPass will be used first.
+        if bitcoin_rpc_user != "NA" || bitcoin_rpc_pass != "NA" {
+            test_auth = Auth::UserPass(bitcoin_rpc_user, bitcoin_rpc_pass);
+        } else if bitcoin_rpc_cookie_path == "NA" {
+            panic!("No User/Pass or Cookie found!");
+        } else {
+            test_auth = Auth::CookieFile(PathBuf::from(&bitcoin_rpc_cookie_path));
+        }
+
+        let test_bitcoin_rpc = Client::new(&bitcoin_rpc_url, test_auth).unwrap();
+
+        //Test UserPass, If it fails, then fall back to CookieFile.
+        match test_bitcoin_rpc.get_best_block_hash() {
+            Ok(value) => {
+                //UserPass test succeeded
+                auth = Auth::UserPass(bitcoin_rpc_user_clone, bitcoin_rpc_pass_clone);
+                value
+            }
+            Err(_) => {
+                let auth_with_cookie = Auth::CookieFile(PathBuf::from(&bitcoin_rpc_cookie_path));
+                info!("UserPass would not authenticate, trying CookieFile now");
+                if bitcoin_rpc_cookie_path == "NA" { 
+                    info!("No CookieFile found!");
+                    panic!()
+                } 
+
+                match Client::new(&bitcoin_rpc_url, auth_with_cookie) {
+                    Ok(alternative_bitcoin_rpc) => {
+                        match alternative_bitcoin_rpc.get_best_block_hash() {
+                            Ok(alternative_value) => {
+                                info!("Cookie File is good!");
+                                auth = Auth::CookieFile(PathBuf::from(&bitcoin_rpc_cookie_path));
+                                alternative_value
+                            }
+                            Err(e) => {
+                                panic!("Cookie File would not authenticate: {}", e)
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Error with User Pass or CookieFile: {}", e)
+                    }
+                }
+            }
+        };
+
+        bitcoin_rpc = Client::new(&bitcoin_rpc_url, auth).unwrap();
 
         #[cfg(feature = "regtest")]
         let regtest_wallet = bitcoin_rpc.create_wallet(&self.wallet_name, None, None, None, None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     }
 
     let config = NetworkConfig::new();
-    let rpc = config.bitcoin_rpc();
+    let rpc = config.bitcoin_rpc()?;
 
     let mining_address = rpc
         .get_new_address(None, None)?


### PR DESCRIPTION
Changed to use cookie file path instead of user and pass, updated config.rs and README.

RPC user + pass worked on BitcoinCore Satoshi:27.99.0, 
but did not work on BitcoinCore Satoshi:28.0.0(inquisition).

Cookies worked though.
