### PR TITLE
Use Cookie If UserPass Fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const POOL_USERS: usize = 10;
 ./bitcoind -signet -addnode=inquisition.bitcoin-signet.net
 ```
 ```bash
+export BITCOIN_RPC_COOKIE_PATH="/home/user/.bitcoin/signet/.cookie"
 export BITCOIN_RPC_USER="rpc_username"
 export BITCOIN_RPC_PASS="rpc_password"
 export SIGNET_WALLET="signet wallet name"
@@ -101,6 +102,7 @@ in regtest we use P2A and v3 transactions to spend. I had a hard time trying to 
 ./bitcoind -regtest -minrelaytxfee=0 -fallbackfee=0.0001
 ```
 ```bash
+export BITCOIN_RPC_COOKIE_PATH="/home/user/.bitcoin/regtest/.cookie"
 export BITCOIN_RPC_USER="rpc_username"
 export BITCOIN_RPC_PASS="rpc_password"
 cargo run --features "regtest"

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     }
 
     let config = NetworkConfig::new();
-    let rpc = config.bitcoin_rpc();
+    let rpc = config.bitcoin_rpc()?;
 
     let mining_address = rpc
         .get_new_address(None, None)?


### PR DESCRIPTION
For bitcoincore_rpc, try UserPass auth first.
If it fails, try cookie file.